### PR TITLE
Feature/security WebFluxSecurity 를 이용한 토큰 인증 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,14 +17,21 @@ ext {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-    runtimeOnly 'com.h2database:h2'
-    runtimeOnly 'mysql:mysql-connector-java'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
+    // https://mvnrepository.com/artifact/javax.servlet/servlet-api
+    compileOnly group: 'javax.servlet', name: 'servlet-api', version: '2.5'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/devit/devitgateway/filter/LoggingFilter.java
+++ b/src/main/java/com/devit/devitgateway/filter/LoggingFilter.java
@@ -1,4 +1,4 @@
-package com.devit.devitgateway.logging;
+package com.devit.devitgateway.filter;
 
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/devit/devitgateway/security/config/ReactiveSecurityConfig.java
+++ b/src/main/java/com/devit/devitgateway/security/config/ReactiveSecurityConfig.java
@@ -1,0 +1,94 @@
+package com.devit.devitgateway.security.config;
+
+import com.devit.devitgateway.security.filter.JwtTokenAuthenticationFilter;
+import com.devit.devitgateway.security.token.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.PermissionEvaluator;
+import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
+import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity;
+import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.security.web.server.context.NoOpServerSecurityContextRepository;
+import reactor.core.publisher.Mono;
+
+import java.io.Serializable;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableReactiveMethodSecurity
+public class ReactiveSecurityConfig {
+
+    private final ApplicationContext applicationContext;
+
+    /**
+     * ServerHttpSecurity는 스프링 시큐리티의 HttpSecurity와 비슷한 웹플럭스용 클래스다.
+     * 이 클래스를 이용하여 모든 요청에 대해 인증 여부 체크를 정의할 수 있다.
+     * 이 클래스에 필터를 추가하여, 요청에 인증용 토큰이 존재할 경우 인증이 되도록 설정할 수 있다.
+     *
+     * SecurityWebFilterChain클래스를 생성하기 전에 DefaultMethodSecurityExpressionHandler클래스가 먼저 구성되어 있어야 한다.
+     * <p>
+     * authenticationEntryPoint: 애플리케이션이 인증을 요청할 때 해야 할 일들을 정의함.
+     * accessDeniedHandler: 인증된 사용자가 필요한 권한을 가지고 있을 않을 때 헤야 할 일들을 정의함.
+     *
+     * @param http
+     * @return
+     */
+    @Bean
+    @DependsOn({"methodSecurityExpressionHandler"})
+    public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http,
+                                                         JwtTokenProvider jwtTokenProvider) {
+        DefaultMethodSecurityExpressionHandler defaultWebSecurityExpressionHandler = this.applicationContext.getBean(DefaultMethodSecurityExpressionHandler.class);
+        defaultWebSecurityExpressionHandler.setPermissionEvaluator(myPermissionEvaluator());
+        return http
+                .exceptionHandling(exceptionHandlingSpec -> exceptionHandlingSpec
+                        .authenticationEntryPoint((exchange, ex) -> {
+                            return Mono.fromRunnable(() -> {
+                                exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+                            });
+                        })
+                        .accessDeniedHandler((exchange, denied) -> {
+                            return Mono.fromRunnable(() -> {
+                                exchange.getResponse().setStatusCode(HttpStatus.FORBIDDEN);
+                            });
+                        }))
+                .csrf().disable()
+                .formLogin().disable()
+                .httpBasic().disable()
+                .securityContextRepository(NoOpServerSecurityContextRepository.getInstance())
+                .authorizeExchange(exchange -> exchange
+                        .pathMatchers(HttpMethod.OPTIONS).permitAll()
+                        .pathMatchers("/api/auth/**").permitAll()
+                        .anyExchange().authenticated()
+                )
+                .addFilterAt(new JwtTokenAuthenticationFilter(jwtTokenProvider), SecurityWebFiltersOrder.HTTP_BASIC)
+                .build();
+    }
+
+    @Bean
+    public PermissionEvaluator myPermissionEvaluator() {
+        return new PermissionEvaluator() {
+            @Override
+            public boolean hasPermission(Authentication authentication, Object targetDomainObject, Object permission) {
+                if(authentication.getAuthorities().stream()
+                        .filter(grantedAuthority -> grantedAuthority.getAuthority().equals(targetDomainObject))
+                        .count() > 0)
+                    return true;
+                return false;
+            }
+
+            @Override
+            public boolean hasPermission(Authentication authentication, Serializable targetId, String targetType, Object permission) {
+                return false;
+            }
+        };
+    }
+
+}

--- a/src/main/java/com/devit/devitgateway/security/filter/JwtTokenAuthenticationFilter.java
+++ b/src/main/java/com/devit/devitgateway/security/filter/JwtTokenAuthenticationFilter.java
@@ -1,0 +1,47 @@
+package com.devit.devitgateway.security.filter;
+
+import com.devit.devitgateway.security.token.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+/**
+ * JWT 토큰이 http request header에 있는지 확인하기 위한 필터
+ * 토근이 있을 경우, 유효성 체크 후, 토큰을 이용하여 인증 정보를 만든다.
+ */
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtTokenAuthenticationFilter implements WebFilter {
+    public static final String HEADER_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        String token = resolveToken(exchange.getRequest());
+        if (StringUtils.hasText(token) && this.jwtTokenProvider.validateToken(token)) {
+            Authentication authentication = this.jwtTokenProvider.getAuthentication(token);
+            return chain.filter(exchange)
+                    .contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication));
+        }
+        return chain.filter(exchange);
+    }
+
+    // 요청으로부터 JWT 토큰을 얻는다.
+    private String resolveToken(ServerHttpRequest request) {
+        String bearerToken = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(HEADER_PREFIX)) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/devit/devitgateway/security/token/JwtTokenProvider.java
+++ b/src/main/java/com/devit/devitgateway/security/token/JwtTokenProvider.java
@@ -1,0 +1,67 @@
+package com.devit.devitgateway.security.token;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    private static final String AUTHORITIES_KEY = "permissions";
+
+    @Value("${security.jjwt.secret}")
+    private String secretKey;
+
+    @Value("${security.jjwt.expiration}")
+    private String expirationTime;
+
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = Jwts.parserBuilder().setSigningKey(this.secretKey.getBytes()).build().parseClaimsJws(token).getBody();
+
+        Object authoritiesClaim = claims.get(AUTHORITIES_KEY);
+
+        Collection<? extends GrantedAuthority> authorities = authoritiesClaim == null ? AuthorityUtils.NO_AUTHORITIES
+                : AuthorityUtils.commaSeparatedStringToAuthorityList(authoritiesClaim.toString());
+
+        User principal = new User(claims.getSubject(), "", authorities);
+
+        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            System.out.println(this.secretKey);
+            System.out.println(token);
+            Jws<Claims> claims = Jwts
+                    .parserBuilder().setSigningKey(this.secretKey.getBytes()).build()
+                    .parseClaimsJws(token);
+            //  parseClaimsJws will check expiration date. No need do here.
+            log.info("expiration date: {}", claims.getBody().getExpiration());
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            log.info("Invalid JWT token: {}", e.getMessage());
+            log.trace("Invalid JWT token trace.", e);
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/devit/devitgateway/security/token/JwtTokenProvider.java
+++ b/src/main/java/com/devit/devitgateway/security/token/JwtTokenProvider.java
@@ -14,13 +14,7 @@ import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
-import javax.crypto.SecretKey;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.Collection;
-import java.util.Date;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Component

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,31 +1,59 @@
 server:
-  port: 8080
+  port: 8000
 
 eureka:
   client:
     fetch-registry: true
     register-with-eureka: true
     service-url:
-      defaultZone: http://localhost:8761/eureka
+      defaultZone: http://54.180.93.206:8761/eureka
   instance:
     instance-id: ${spring.application.name}:${spring.application.instance_id:${random.value}}
 
 spring:
   application:
     name: gateway-service
-
   cloud:
     gateway:
       routes:
         - id: payment-service
           uri: lb://PAYMENT-SERVICE
           predicates:
-            - Path=/payment/**
+            - Path=/api/payment/**
           filters:
-            - RewritePath=/payment/?(?<segment>.*), /$\{segment}
-            #            - CustomAuthFilter
+            - RewritePath=/api/payment/?(?<segment>.*), /$\{segment}
+#            - CustomAuthFilter
             - name: LoggingFilter
               args:
                 baseMessage: payment-service
                 preLogger: true
                 postLogger: true
+        - id: certification-service
+          uri: lb://CERTIFICATION-SERVICE
+          predicates:
+            - Path=/api/auth/**
+          filters:
+            - RewritePath=/api/auth/?(?<segment>.*), /$\{segment}
+#            - CustomAuthFilter
+            - name: LoggingFilter
+              args:
+                baseMessage: certification-service
+                preLogger: true
+                postLogger: true
+
+app:
+  auth:
+    tokenExpiry: 10800000            # 3시간
+    refreshTokenExpiry: 604800000    # 7일
+
+cors:
+  allowed-origins: http://localhost:8000
+  allowed-methods: GET,POST,PUT,DELETE,OPTIONS
+  allowed-headers: \*
+  exposed-headers: Set-Cookie
+  max-age: 3600
+
+security:
+  jjwt:
+    secret: '50g/NGsxw15SwkKw8f+fxuXw6hBrEVYXCgJwyzItp8I='
+    expiration: 3366000


### PR DESCRIPTION
https://sthwin.tistory.com/24
위 글을 따라 Gateway 에 토큰 인증을 구현해보았습니다.

토큰이 없거나 잘못된 경우 401 에러로 응답하며 
<img width="979" alt="스크린샷 2022-07-06 오전 11 43 02" src="https://user-images.githubusercontent.com/84092014/177456671-4f3216ac-7b9e-4819-806e-9da3e07ffb0c.png">

토큰이 있는 경우 yml 에 작성한 대로 요청이 라우팅 됩니다.
<img width="974" alt="스크린샷 2022-07-06 오전 11 43 25" src="https://user-images.githubusercontent.com/84092014/177456728-3c981e4f-02b4-4ccd-8642-d015b2ecf646.png">

인증 서비스의 경우 permit All 로 설정하여 모든 요청을 허용하였습니다. 
<img width="968" alt="스크린샷 2022-07-06 오전 11 43 56" src="https://user-images.githubusercontent.com/84092014/177456808-1e9b3510-6742-4c7e-b62f-11ef6909d27e.png">

